### PR TITLE
Refactor receiveMessageClientCache to use Map and improve response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ The main difference is that batch operations are not limited to 10 items, but ac
 
 ## License
 Licensed under [MIT](./LICENSE).
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "@fgiova/mini-sqs-client",
-	"version": "3.4.0",
+	"version": "4.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@fgiova/mini-sqs-client",
-			"version": "3.4.0",
+			"version": "4.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@fgiova/aws-signature": "^4.0.0",
-				"undici": "^7.21.0"
+				"@fgiova/aws-signature": "^4.2.0",
+				"undici": "^7.25.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.2.2",
@@ -358,9 +358,9 @@
 			}
 		},
 		"node_modules/@fgiova/aws-signature": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@fgiova/aws-signature/-/aws-signature-4.0.0.tgz",
-			"integrity": "sha512-PNWIBR7CRnB83VV699XRaW3q+YuAYCJEO4Z0Zv33W/RqI1B4es2WHlevI89l3ALBXQKdeEQ1Il/hhJZ8vXngIg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@fgiova/aws-signature/-/aws-signature-4.2.0.tgz",
+			"integrity": "sha512-VQF2w6bkmbAaAmUlTwZSsEeTs/wmsz3eo9sRJw5jmBd27VnqXzCw/rSQUN/6cB0CZ05Ixh7D91k0ODrYs2AzzQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@sinclair/typebox": "^0.34.48",
@@ -10928,9 +10928,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
-			"integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
 		"show-full-coverage": true
 	},
 	"dependencies": {
-		"@fgiova/aws-signature": "^4.0.0",
-		"undici": "^7.21.0"
+		"@fgiova/aws-signature": "^4.2.0",
+		"undici": "^7.25.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.2.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export class MiniSQSClient {
 	private readonly region: string;
 	private readonly endpoint: string;
 	private defaultDestroySigner = true;
-	private receiveMessageClientCache: Record<string, Client> = {};
+	private receiveMessageClientCache: Map<number, Client> = new Map();
 
 	constructor(
 		region: string,
@@ -61,12 +61,36 @@ export class MiniSQSClient {
 		const result = await Promise.all([
 			this.pool.destroy(),
 			(signer && this.signer.destroy()) || true,
-			...Object.keys(this.receiveMessageClientCache).map((key) =>
-				this.receiveMessageClientCache[key].destroy(),
+			...Array.from(this.receiveMessageClientCache.values()).map((client) =>
+				client.destroy(),
 			),
 		]);
-		this.receiveMessageClientCache = {};
+		this.receiveMessageClientCache.clear();
 		return result;
+	}
+
+	private async readText(
+		body: Dispatcher.ResponseData["body"],
+	): Promise<string> {
+		try {
+			return await body.text();
+		} catch (err) {
+			try {
+				await body.dump();
+			} catch {}
+			throw err;
+		}
+	}
+
+	private async readJson<T>(body: Dispatcher.ResponseData["body"]): Promise<T> {
+		try {
+			return (await body.json()) as T;
+		} catch (err) {
+			try {
+				await body.dump();
+			} catch {}
+			throw err;
+		}
 	}
 
 	private getQueueARN(queueARN: string) {
@@ -125,7 +149,7 @@ export class MiniSQSClient {
 			body: requestBody,
 		});
 		if (response.statusCode !== 200) {
-			let message = await response.body.text();
+			let message = await this.readText(response.body);
 			try {
 				const parsedBody = JSON.parse(message);
 				if (parsedBody.message) {
@@ -138,7 +162,7 @@ export class MiniSQSClient {
 			throw Error(message);
 		}
 		if (JSONResponse) {
-			return (await response.body.json()) as R;
+			return await this.readJson<R>(response.body);
 		}
 		await response.body.dump();
 		return true as R;
@@ -242,46 +266,29 @@ export class MiniSQSClient {
 		return true;
 	}
 
-	private receiveMessageClient(
-		timeout: number,
-		clientClass?: {
-			prototype: Client;
-			new (): Client;
-		},
-	) {
-		/* c8 ignore next 1 */
-		const clientClassConstructor = clientClass || Client;
-		const clientClassCacheName = `${clientClassConstructor.name}-${timeout}`;
-
-		if (this.receiveMessageClientCache[clientClassCacheName]) {
-			return this.receiveMessageClientCache[clientClassCacheName];
-		}
-
+	private receiveMessageClient(timeout: number) {
 		const globalDispatcher = getGlobalDispatcher();
-
-		if (globalDispatcher instanceof MockAgent && !clientClass) {
+		if (globalDispatcher instanceof MockAgent) {
 			return (globalDispatcher as MockAgent).get(this.endpoint);
 		}
 
-		this.receiveMessageClientCache[clientClassCacheName] =
-			new clientClassConstructor(this.endpoint, {
-				...this.undiciOptions,
-				connect: {
-					...this.undiciOptions?.connect,
-					timeout: timeout,
-				},
-				bodyTimeout: timeout,
-				keepAliveMaxTimeout: 21_000,
-			});
+		const cached = this.receiveMessageClientCache.get(timeout);
+		if (cached) return cached;
 
-		return this.receiveMessageClientCache[clientClassCacheName];
+		const client = new Client(this.endpoint, {
+			...this.undiciOptions,
+			connect: {
+				...this.undiciOptions?.connect,
+				timeout: timeout,
+			},
+			bodyTimeout: timeout,
+			keepAliveMaxTimeout: 21_000,
+		});
+		this.receiveMessageClientCache.set(timeout, client);
+		return client;
 	}
 
-	async receiveMessage(
-		queueARN: string,
-		receiveMessage: ReceiveMessage,
-		clientClass?: { prototype: Client; new (): Client },
-	) {
+	async receiveMessage(queueARN: string, receiveMessage: ReceiveMessage) {
 		const { region, accountId, queueName, host } = this.getQueueARN(queueARN);
 		receiveMessage.WaitTimeSeconds =
 			Number(receiveMessage.WaitTimeSeconds) > 20 ||
@@ -309,7 +316,7 @@ export class MiniSQSClient {
 
 		const timeout = receiveMessage.WaitTimeSeconds * 1000 + 1000;
 
-		const client = this.receiveMessageClient(timeout, clientClass);
+		const client = this.receiveMessageClient(timeout);
 
 		const response = await client.request({
 			path: `/${accountId}/${queueName}/`,
@@ -324,9 +331,9 @@ export class MiniSQSClient {
 		});
 
 		if (response.statusCode !== 200) {
-			throw Error(await response.body.text());
+			throw Error(await this.readText(response.body));
 		}
-		return (await response.body.json()) as ReceiveMessageResult;
+		return await this.readJson<ReceiveMessageResult>(response.body);
 	}
 
 	async changeMessageVisibility(

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,10 @@ export class MiniSQSClient {
 		this.pool =
 			globalDispatcher instanceof MockAgent
 				? (globalDispatcher as MockAgent).get(this.endpoint)
-				: new Pool(this.endpoint, undiciOptions);
+				: new Pool(this.endpoint, {
+						...undiciOptions,
+						clientTtl: 60 * 60 * 1000,
+					});
 
 		if (signer instanceof Signer) {
 			this.signer = signer;

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -158,4 +158,73 @@ test("MiniSQSClient Errors", async (t) => {
 			"messages must be an array",
 		);
 	});
+
+	await t.test("sendMessage invalid JSON success body", async (t) => {
+		const { mockPool, client } = t.context;
+		const message: SendMessage = { MessageBody: "Hello World!" };
+		mockPool
+			.intercept({
+				path: "/000000000000/test/",
+				method: "POST",
+				body: JSON.stringify(message),
+			})
+			.reply(200, "not-json", {
+				headers: { "content-type": "application/json" },
+			});
+		await t.rejects(client.sendMessage(queueARN, message));
+	});
+
+	await t.test("readText body throws, dump succeeds", async (t) => {
+		const { client } = t.context;
+		const readErr = new Error("read fail");
+		const fakeBody = {
+			text: () => Promise.reject(readErr),
+			dump: () => Promise.resolve(),
+		};
+		// biome-ignore lint/suspicious/noExplicitAny: access private for coverage
+		await t.rejects((client as any).readText(fakeBody), readErr);
+	});
+
+	await t.test("readText body throws, dump throws", async (t) => {
+		const { client } = t.context;
+		const readErr = new Error("read fail");
+		const fakeBody = {
+			text: () => Promise.reject(readErr),
+			dump: () => Promise.reject(new Error("dump fail")),
+		};
+		// biome-ignore lint/suspicious/noExplicitAny: access private for coverage
+		await t.rejects((client as any).readText(fakeBody), readErr);
+	});
+
+	await t.test("readJson body throws, dump succeeds", async (t) => {
+		const { client } = t.context;
+		const readErr = new Error("json fail");
+		const fakeBody = {
+			json: () => Promise.reject(readErr),
+			dump: () => Promise.resolve(),
+		};
+		// biome-ignore lint/suspicious/noExplicitAny: access private for coverage
+		await t.rejects((client as any).readJson(fakeBody), readErr);
+	});
+
+	await t.test("receiveMessageClient caches per timeout", async (t) => {
+		const client = new MiniSQSClient("eu-central-1");
+		// biome-ignore lint/suspicious/noExplicitAny: access private for coverage
+		const c1 = (client as any).receiveMessageClient(21000);
+		// biome-ignore lint/suspicious/noExplicitAny: access private for coverage
+		const c2 = (client as any).receiveMessageClient(21000);
+		t.equal(c1, c2);
+		await client.destroy();
+	});
+
+	await t.test("readJson body throws, dump throws", async (t) => {
+		const { client } = t.context;
+		const readErr = new Error("json fail");
+		const fakeBody = {
+			json: () => Promise.reject(readErr),
+			dump: () => Promise.reject(new Error("dump fail")),
+		};
+		// biome-ignore lint/suspicious/noExplicitAny: access private for coverage
+		await t.rejects((client as any).readJson(fakeBody), readErr);
+	});
 });

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -5,7 +5,7 @@ process.env.AWS_SECRET_ACCESS_KEY = "bar";
 process.env.AWS_REGION = "eu-central-1";
 
 import { randomUUID } from "node:crypto";
-import { type Client, MockAgent, MockClient } from "undici";
+import { MockAgent } from "undici";
 import { MiniSQSClient, type SendMessage } from "../src";
 
 const queueARN = "arn:aws:sqs:eu-central-1:000000000000:test";
@@ -133,32 +133,21 @@ test("MiniSQSClient Errors", async (t) => {
 	});
 
 	await t.test("receiveMessage Error", async (t) => {
-		const { mockAgent, client } = t.context;
-		class MockClientLocal extends MockClient {
-			constructor(endpoint: string, options: Client.Options) {
-				super(endpoint, {
-					...options,
-					agent: mockAgent,
-				});
-
-				this.intercept({
-					path: "/000000000000/test/",
-					method: "POST",
-					headers: (headers: Record<string, string>) => {
-						return headers["x-amz-target"] === "AmazonSQS.ReceiveMessage";
-					},
-				}).reply(500, "Generic Error");
-			}
-		}
+		const { mockPool, client } = t.context;
+		mockPool
+			.intercept({
+				path: "/000000000000/test/",
+				method: "POST",
+				headers: (headers: Record<string, string>) => {
+					return headers["x-amz-target"] === "AmazonSQS.ReceiveMessage";
+				},
+			})
+			.reply(500, "Generic Error");
 
 		await t.rejects(
-			client.receiveMessage(
-				queueARN,
-				{
-					WaitTimeSeconds: 20,
-				},
-				MockClientLocal,
-			),
+			client.receiveMessage(queueARN, {
+				WaitTimeSeconds: 20,
+			}),
 		);
 	});
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -5,13 +5,7 @@ process.env.AWS_SECRET_ACCESS_KEY = "bar";
 
 import { createHash, randomUUID } from "node:crypto";
 import { Signer } from "@fgiova/aws-signature";
-import {
-	type Client,
-	getGlobalDispatcher,
-	MockAgent,
-	MockClient,
-	setGlobalDispatcher,
-} from "undici";
+import { getGlobalDispatcher, MockAgent, setGlobalDispatcher } from "undici";
 import {
 	type BatchResultErrorEntry,
 	MiniSQSClient,
@@ -341,7 +335,7 @@ test("MiniSQSClient", { only: true }, async (t) => {
 	});
 
 	await t.test("receiveMessage", async (t) => {
-		const { mockAgent, client } = t.context;
+		const { mockPool, client } = t.context;
 		const messagesData = [
 			{
 				Body: "Hello World!",
@@ -349,38 +343,27 @@ test("MiniSQSClient", { only: true }, async (t) => {
 				MessageId: randomUUID(),
 			},
 		];
-		class MockClientLocal extends MockClient {
-			constructor(endpoint: string, options: Client.Options) {
-				super(endpoint, {
-					...options,
-					agent: mockAgent,
-				});
+		mockPool
+			.intercept({
+				path: "/000000000000/test/",
+				method: "POST",
+				headers: (headers: Record<string, string>) => {
+					return headers["x-amz-target"] === "AmazonSQS.ReceiveMessage";
+				},
+			})
+			.reply(200, {
+				Messages: messagesData,
+			});
 
-				this.intercept({
-					path: "/000000000000/test/",
-					method: "POST",
-					headers: (headers: Record<string, string>) => {
-						return headers["x-amz-target"] === "AmazonSQS.ReceiveMessage";
-					},
-				}).reply(200, {
-					Messages: messagesData,
-				});
-			}
-		}
-
-		const messages = await client.receiveMessage(
-			queueARN,
-			{
-				WaitTimeSeconds: 20,
-			},
-			MockClientLocal,
-		);
+		const messages = await client.receiveMessage(queueARN, {
+			WaitTimeSeconds: 20,
+		});
 		t.same(messages, {
 			Messages: messagesData,
 		});
 	});
-	await t.test("receiveMessage cached client", async (t) => {
-		const { mockAgent, client } = t.context;
+	await t.test("receiveMessage repeated calls", async (t) => {
+		const { mockPool, client } = t.context;
 		const messagesData = [
 			{
 				Body: "Hello World!",
@@ -388,43 +371,27 @@ test("MiniSQSClient", { only: true }, async (t) => {
 				MessageId: randomUUID(),
 			},
 		];
-		class MockClientLocal extends MockClient {
-			constructor(endpoint: string, options: Client.Options) {
-				super(endpoint, {
-					...options,
-					agent: mockAgent,
-				});
+		mockPool
+			.intercept({
+				path: "/000000000000/test/",
+				method: "POST",
+				headers: (headers: Record<string, string>) => {
+					return headers["x-amz-target"] === "AmazonSQS.ReceiveMessage";
+				},
+			})
+			.reply(200, {
+				Messages: messagesData,
+			})
+			.times(2);
 
-				this.intercept({
-					path: "/000000000000/test/",
-					method: "POST",
-					headers: (headers: Record<string, string>) => {
-						return headers["x-amz-target"] === "AmazonSQS.ReceiveMessage";
-					},
-				})
-					.reply(200, {
-						Messages: messagesData,
-					})
-					.times(2);
-			}
-		}
-
-		const first = await client.receiveMessage(
-			queueARN,
-			{
-				WaitTimeSeconds: 20,
-			},
-			MockClientLocal,
-		);
+		const first = await client.receiveMessage(queueARN, {
+			WaitTimeSeconds: 20,
+		});
 		t.same(first, { Messages: messagesData });
 
-		const second = await client.receiveMessage(
-			queueARN,
-			{
-				WaitTimeSeconds: 20,
-			},
-			MockClientLocal,
-		);
+		const second = await client.receiveMessage(queueARN, {
+			WaitTimeSeconds: 20,
+		});
 		t.same(second, { Messages: messagesData });
 	});
 	await t.test("receiveMessage with Mocks", async (t) => {
@@ -472,7 +439,7 @@ test("MiniSQSClient", { only: true }, async (t) => {
 		});
 	});
 	await t.test("receiveMessage cap waitTime", async (t) => {
-		const { mockAgent, client } = t.context;
+		const { mockPool, client } = t.context;
 		const messagesData = [
 			{
 				Body: "Hello World!",
@@ -480,36 +447,25 @@ test("MiniSQSClient", { only: true }, async (t) => {
 				MessageId: randomUUID(),
 			},
 		];
-		class MockClientLocal extends MockClient {
-			constructor(endpoint: string, options: Client.Options) {
-				super(endpoint, {
-					...options,
-					agent: mockAgent,
-				});
+		mockPool
+			.intercept({
+				path: "/000000000000/test/",
+				method: "POST",
+				headers: (headers: Record<string, string>) => {
+					return headers["x-amz-target"] === "AmazonSQS.ReceiveMessage";
+				},
+				body: (body: string) => {
+					const bodyData = JSON.parse(body);
+					return bodyData.WaitTimeSeconds === 20;
+				},
+			})
+			.reply(200, {
+				Messages: messagesData,
+			});
 
-				this.intercept({
-					path: "/000000000000/test/",
-					method: "POST",
-					headers: (headers: Record<string, string>) => {
-						return headers["x-amz-target"] === "AmazonSQS.ReceiveMessage";
-					},
-					body: (body: string) => {
-						const bodyData = JSON.parse(body);
-						return bodyData.WaitTimeSeconds === 20;
-					},
-				}).reply(200, {
-					Messages: messagesData,
-				});
-			}
-		}
-
-		const messages = await client.receiveMessage(
-			queueARN,
-			{
-				WaitTimeSeconds: 50,
-			},
-			MockClientLocal,
-		);
+		const messages = await client.receiveMessage(queueARN, {
+			WaitTimeSeconds: 50,
+		});
 		t.same(messages, {
 			Messages: messagesData,
 		});


### PR DESCRIPTION
This pull request refactors the `MiniSQSClient` to simplify client caching, improve error handling for response bodies, and update dependencies. It removes the ability to inject custom client classes for message receiving, standardizes the caching mechanism for receive clients, and adds more robust error handling and test coverage for edge cases.

Key changes include:

### Refactoring and Simplification

* Refactored `receiveMessageClientCache` from an object keyed by string to a `Map<number, Client>`, simplifying client caching to be per-timeout only, and removed support for passing custom client classes to `receiveMessage`. (`src/index.ts`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L32-R32) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L245-R281) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L276-R294) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L312-R322)
* Updated all usages and tests to remove the custom client class parameter, relying solely on the internal caching mechanism. (`src/index.ts`, `test/index.ts`, `test/errors.ts`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L276-R294) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L312-R322) [[3]](diffhunk://#diff-177d97aec07fd5b22f04049b34d74939b1d8364a7a83e8fb69ee3ee8695105fbL344-R375) [[4]](diffhunk://#diff-177d97aec07fd5b22f04049b34d74939b1d8364a7a83e8fb69ee3ee8695105fbL409-R394) [[5]](diffhunk://#diff-177d97aec07fd5b22f04049b34d74939b1d8364a7a83e8fb69ee3ee8695105fbL475-R451) [[6]](diffhunk://#diff-177d97aec07fd5b22f04049b34d74939b1d8364a7a83e8fb69ee3ee8695105fbL500-R468) [[7]](diffhunk://#diff-511171977adb92d235efc81dc29bb6f629e48d616c7e75d1dd87fe479b0a5e5fL136-R150)

### Error Handling Improvements

* Added private helper methods `readText` and `readJson` to handle response body reading with improved error handling and cleanup (calls `dump()` on error). All response parsing now uses these helpers. (`src/index.ts`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L64-R98) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L128-R155) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L141-R168) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L327-R339)
* Expanded test coverage for error scenarios, including cases where body reading or dumping fails, and when invalid JSON is returned with a 200 status code. (`test/errors.ts`)

### Dependency Updates

* Updated `@fgiova/aws-signature` to `^4.2.0` and `undici` to `^7.25.0` in `package.json`.

### Test and Import Cleanups

* Removed unused imports and updated test setup to use the simplified client caching and mocking approach. (`test/index.ts`, `test/errors.ts`) [[1]](diffhunk://#diff-177d97aec07fd5b22f04049b34d74939b1d8364a7a83e8fb69ee3ee8695105fbL8-R8) [[2]](diffhunk://#diff-511171977adb92d235efc81dc29bb6f629e48d616c7e75d1dd87fe479b0a5e5fL8-R8)

### Minor

* Added a newline at the end of `README.md`.